### PR TITLE
Fix temporary file cleanup on verification failure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,7 @@ bool verificar(int N, const fs::path& original){
         tmp.close();
 
         if(!verificar_archivos(original.string(), "tmp.txt")){
+            fs::remove("tmp.txt");
             std::cerr << "Fallo en copia "<<i<<"\n";
             return false;
         }


### PR DESCRIPTION
## Summary
- ensure `tmp.txt` is removed even when verification fails

## Testing
- `cmake --build build --parallel`
- `./build/flujo original.txt 10`

------
https://chatgpt.com/codex/tasks/task_b_685cd7e16f74832ca058704947892c3f