### PR TITLE
Remove range-for loops for C++98 compatibility

### DIFF
--- a/src/cifrado.cpp
+++ b/src/cifrado.cpp
@@ -23,11 +23,15 @@ static char descifraChar(char c) {
 }
 std::string cifrar(const std::string& in){
     std::string out = in;
-    for(char& c: out) c = cifraChar(c);
+    for(std::string::iterator it = out.begin(); it != out.end(); ++it){
+        *it = cifraChar(*it);
+    }
     return out;
 }
 std::string descifrar(const std::string& in){
     std::string out = in;
-    for(char& c: out) c = descifraChar(c);
+    for(std::string::iterator it = out.begin(); it != out.end(); ++it){
+        *it = descifraChar(*it);
+    }
     return out;
 }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -13,7 +13,9 @@ std::array<unsigned char,32> hash_sha256(const std::string& data){
 }
 std::string hash_to_hex(const std::array<unsigned char,32>& h){
     std::ostringstream oss;
-    for(unsigned char b: h)
+    for(std::size_t i = 0; i < h.size(); ++i){
+        unsigned char b = h[i];
         oss << std::hex << std::setw(2) << std::setfill('0') << (int)b;
+    }
     return oss.str();
 }

--- a/src/main_opt.cpp
+++ b/src/main_opt.cpp
@@ -72,7 +72,10 @@ int main(int argc, char* argv[]){
         threads.emplace_back(process_file, i, std::cref(original),
                              std::cref(orig_data), std::ref(any_fail));
     }
-    for(auto& t: threads) t.join();
+    for(std::vector<std::thread>::iterator it = threads.begin();
+        it != threads.end(); ++it){
+        it->join();
+    }
     auto TFIN = Clock::now();
 
     auto TT = std::chrono::duration_cast<std::chrono::milliseconds>(TFIN-TI).count();


### PR DESCRIPTION
## Summary
- replace range-based loops with iterator loops

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_b_686be4760ac4832c80a4c120e62c5e16